### PR TITLE
feat(ai): enrich metadata verification with embedded tags + narrator/year

### DIFF
--- a/src/audiobook_optimizer/adapters/ai_batch.py
+++ b/src/audiobook_optimizer/adapters/ai_batch.py
@@ -21,6 +21,21 @@ class AudiobookVerification(BaseModel):
     author: str = Field(description="Corrected author (FirstName LastName format)")
     series: str | None = Field(default=None, description="Series name if part of a series")
     series_number: float | None = Field(default=None, description="Position in series")
+    narrator: str | None = Field(
+        default=None,
+        description=(
+            "Narrator/reader name if confidently known. Often the embedded "
+            "`composer` tag — leave null when not confident."
+        ),
+    )
+    year: int | None = Field(
+        default=None,
+        description=(
+            "Original publication year (4-digit) if confidently known. The "
+            "embedded `date` tag is usually the recording year — leave null "
+            "when ambiguous."
+        ),
+    )
     quality_ok: bool = Field(default=True, description="Whether quality settings are acceptable")
     quality_note: str | None = Field(default=None, description="Note about quality if not ok")
     changes: list[str] = Field(default_factory=list, description="List of changes made")
@@ -34,18 +49,41 @@ class BatchVerificationResult(BaseModel):
 
 
 _INSTRUCTIONS = """You are an audiobook metadata expert. You will receive a batch of audiobooks
-with their inferred metadata and quality settings. Your job is to:
+with their inferred metadata, embedded source tags, and quality settings. Your job is to:
 
-1. VERIFY metadata is correct (title, author, series)
-2. FIX obvious errors (swapped author/title, missing series detection, typos)
+1. VERIFY metadata is correct (title, author, series, narrator, year)
+2. FIX obvious errors (swapped author/title, missing series detection, typos,
+   leading track numbers like "01" baked into titles, quality/size tags in titles)
 3. VALIDATE quality decisions (bitrate choices)
 
 METADATA RULES:
 - Author format: "FirstName LastName" (not "LastName, FirstName")
-- Series names: Clean (e.g., "Discworld" not "Discworld Series")
-- Remove quality tags from titles: "(Stevens) 32k", "{179mb}", etc.
-- Remove year prefixes unless part of actual title
-- Detect series from context (e.g., "Book 1", "Vol. 2", numbered titles)
+- Series names: clean and consistent ("Discworld", not "Discworld Series",
+  not "Discworld (Books)"). Use "The Hitchhiker's Guide to the Galaxy" (with
+  the leading "The" and the apostrophe) for that series, not "Hitchhikers...".
+- Remove quality/size tags ("(Stevens) 32k 12.58.21 {179mb}"), bitrate
+  ({179mb}, 64k), and disc/track prefixes from titles. Example:
+  "01Hitchhiker's Guide to the Galaxy (audiobook)" -> "The Hitchhiker's Guide to the Galaxy".
+- Remove year prefixes ("2008 - ...") unless that year is part of the actual title.
+- Detect series from context: numbered prefixes ("Book 1", "Vol. 2"),
+  parent directory names, and the embedded `album` tag (often holds the series
+  name when the book is part of one).
+
+USING EMBEDDED TAGS:
+- The embedded audio tags (artist, albumartist, album, composer, date,
+  comment, genre, title) are the richest signal — prefer them over folder-name
+  guesses when they are sane.
+- The embedded `composer` tag is FREQUENTLY the narrator — return it as
+  `narrator` when it is a plausible person name distinct from the author.
+- The embedded `date` tag is usually the (re)recording year — return it as
+  `year` only when it is a 4-digit year and plausible for that work.
+- Embedded tags CAN be wrong: a re-recording or a mislabeled rip may carry
+  the wrong artist/album (e.g. a Hitchhiker's rip tagged with Stephen Fry
+  or Martin Freeman as composer when the user wants the Douglas-Adams-narrated
+  edition). Sanity-check against the author's known works — if the embedded
+  artist/album/composer contradicts a famous title, trust the title.
+- Return `narrator` and `year` ONLY when reasonably confident; leave null
+  otherwise (downstream code falls back to the existing metadata value).
 
 QUALITY RULES:
 - Bitrate capping is CORRECT: never upscale (24kbps source → 24kbps output is right)
@@ -60,10 +98,20 @@ def _format_items(items: list[dict]) -> str:
     """Format items for prompt."""
     lines = []
     for item in items:
-        lines.append(f"[{item['index']}] {item['folder']}")
-        lines.append(
-            f"    Files: {item['file_count']} ({', '.join(item['files'][:3])}{'...' if len(item['files']) > 3 else ''})"
-        )
+        parent = item.get("parent_folder")
+        head = f"[{item['index']}] {item['folder']}"
+        if parent:
+            head += f"  (parent dir: {parent})"
+        lines.append(head)
+        files_preview = ", ".join(item["files"][:3]) + ("..." if len(item["files"]) > 3 else "")
+        files_line = f"    Files: {item['file_count']} ({files_preview})"
+        if item.get("total_hours") is not None:
+            files_line += f", ~{item['total_hours']}h total"
+        lines.append(files_line)
+        tags = item.get("embedded_tags") or {}
+        present = {k: v for k, v in tags.items() if v}
+        if present:
+            lines.append("    Embedded tags: " + "; ".join(f"{k}={v}" for k, v in present.items()))
         lines.append(f'    Inferred: "{item["inferred"]["title"]}" by {item["inferred"]["author"]}')
         if item["inferred"]["series"]:
             lines.append(f"    Series: {item['inferred']['series']} #{item['inferred']['series_number']}")
@@ -139,14 +187,36 @@ class BatchAIVerifier:
         if not audiobooks:
             return {}
 
-        # Build items list - cachekit will JSON-serialize for cache key
+        # Local extractor: reuses mutagen tag-reading from FilesystemMetadataExtractor
+        # so the prompt carries the richest available signal (artist/album/composer/date/...).
+        # Local import to avoid a circular module-load dependency.
+        from audiobook_optimizer.adapters.filesystem import FilesystemMetadataExtractor
+
+        extractor = FilesystemMetadataExtractor()
+
+        # Build items list - cachekit will JSON-serialize for cache key. Changing
+        # the dict shape (parent_folder, total_hours, embedded_tags) naturally
+        # invalidates stale cache entries from the pre-enrichment build.
         items = []
         for source, metadata, quality in audiobooks:
+            tags = extractor.read_embedded_tags(source)
+            # Prefer the AudiobookSource.total_duration_ms when populated; fall back
+            # to summing individual files. Both are in milliseconds.
+            total_ms = source.total_duration_ms or sum(
+                f.duration_ms for f in source.audio_files if f.duration_ms
+            )
+            total_hours = round(total_ms / 3_600_000, 1) if total_ms else None
+            # Truncate long tag values (comment can be a multi-paragraph description)
+            # to keep prompt size + cache key bounded.
+            safe_tags = {k: (v[:300] if isinstance(v, str) else v) for k, v in tags.items()}
             items.append(
                 {
                     "folder": source.source_path.name,
+                    "parent_folder": source.source_path.parent.name,
                     "files": [f.path.name for f in source.audio_files[:5]],
                     "file_count": len(source.audio_files),
+                    "total_hours": total_hours,
+                    "embedded_tags": safe_tags,
                     "inferred": {
                         "title": metadata.title,
                         "author": metadata.author,
@@ -168,14 +238,18 @@ def apply_verification(
     metadata: AudiobookMetadata,
     verification: AudiobookVerification,
 ) -> AudiobookMetadata:
-    """Apply AI verification to metadata, returning updated copy."""
+    """Apply AI verification to metadata, returning updated copy.
+
+    AI-returned `narrator` / `year` win when present, otherwise fall back to
+    the inferred values — never overwrite known data with null.
+    """
     return AudiobookMetadata(
         title=verification.title,
         author=verification.author,
         series=verification.series,
         series_number=verification.series_number,
-        narrator=metadata.narrator,
-        year=metadata.year,
+        narrator=verification.narrator or metadata.narrator,
+        year=verification.year or metadata.year,
         description=metadata.description,
         genre=metadata.genre,
         cover_path=metadata.cover_path,

--- a/src/audiobook_optimizer/adapters/ai_batch.py
+++ b/src/audiobook_optimizer/adapters/ai_batch.py
@@ -24,8 +24,7 @@ class AudiobookVerification(BaseModel):
     narrator: str | None = Field(
         default=None,
         description=(
-            "Narrator/reader name if confidently known. Often the embedded "
-            "`composer` tag — leave null when not confident."
+            "Narrator/reader name if confidently known. Often the embedded `composer` tag — leave null when not confident."
         ),
     )
     year: int | None = Field(
@@ -202,9 +201,7 @@ class BatchAIVerifier:
             tags = extractor.read_embedded_tags(source)
             # Prefer the AudiobookSource.total_duration_ms when populated; fall back
             # to summing individual files. Both are in milliseconds.
-            total_ms = source.total_duration_ms or sum(
-                f.duration_ms for f in source.audio_files if f.duration_ms
-            )
+            total_ms = source.total_duration_ms or sum(f.duration_ms for f in source.audio_files if f.duration_ms)
             total_hours = round(total_ms / 3_600_000, 1) if total_ms else None
             # Truncate long tag values (comment can be a multi-paragraph description)
             # to keep prompt size + cache key bounded.

--- a/src/audiobook_optimizer/adapters/filesystem.py
+++ b/src/audiobook_optimizer/adapters/filesystem.py
@@ -454,6 +454,45 @@ class FilesystemMetadataExtractor(MetadataExtractor):
     def _clean_name(name: str) -> str:
         return clean_name(name)
 
+    def read_embedded_tags(self, source: AudiobookSource) -> dict[str, str | None]:
+        """Read the embedded audio tags from the first source file as a flat dict.
+
+        Returns keys: artist, albumartist, album, composer, date, comment, genre, title.
+        Values are None when unreadable/absent. Used to enrich the AI verification
+        prompt with the richest available source-of-truth tags. Reads only the first
+        file (representative — taggers usually copy the same series-level tags across
+        all tracks in a release).
+
+        Reuses the lazy `mutagen` import and `_get_tag` helper. Wrapped in try/except
+        so an unreadable file degrades to all-None instead of failing the run.
+        """
+        keys = ("artist", "albumartist", "album", "composer", "date", "comment", "genre", "title")
+        empty: dict[str, str | None] = {k: None for k in keys}
+        if not self._mutagen or not source.audio_files:
+            return empty
+        try:
+            f = self._mutagen.File(source.audio_files[0].path)
+            if not f or not getattr(f, "tags", None):
+                return empty
+            tags = f.tags
+            return {
+                "artist": self._get_tag(tags, ["TPE1", "artist", "\xa9ART"]),
+                "albumartist": self._get_tag(tags, ["TPE2", "albumartist", "aART"]),
+                "album": self._get_tag(tags, ["TALB", "album", "\xa9alb"]),
+                "composer": self._get_tag(tags, ["TCOM", "composer", "\xa9wrt"]),
+                "date": self._get_tag(tags, ["TDRC", "TYER", "date", "\xa9day"]),
+                "comment": self._get_tag(tags, ["COMM::eng", "COMM", "comment", "\xa9cmt"]),
+                "genre": self._get_tag(tags, ["TCON", "genre", "\xa9gen"]),
+                "title": self._get_tag(tags, ["TIT2", "title", "\xa9nam"]),
+            }
+        except Exception:
+            logger.debug(
+                "Failed to read embedded tags from %s",
+                source.audio_files[0].path,
+                exc_info=True,
+            )
+            return empty
+
     def _infer_author_from_files(self, source: AudiobookSource) -> str | None:
         """Try to get author from embedded tags in audio files."""
         if not self._mutagen or not source.audio_files:

--- a/src/audiobook_optimizer/cli.py
+++ b/src/audiobook_optimizer/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for audiobook-optimizer."""
 
+import logging
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -13,6 +14,8 @@ from rich.table import Table
 from audiobook_optimizer.config import ai_available, get_settings
 from audiobook_optimizer.domain.models import ProcessingStatus
 from audiobook_optimizer.services.processor import AudiobookProcessor
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     name="audiobook-optimizer",
@@ -316,9 +319,11 @@ def process(
     ),
 ) -> None:
     """Process audiobooks: convert to M4B and organize."""
-    # Show AI status
+    # Show AI status — explicit on/off so pod logs never leave it ambiguous.
     if state.ai_enabled:
         console.print("[dim]AI verification enabled[/dim]")
+    else:
+        console.print("[dim]AI verification skipped (no ANTHROPIC_API_KEY or --no-ai)[/dim]")
 
     processor = AudiobookProcessor(
         source_dir=source,
@@ -386,8 +391,18 @@ def process(
 
             if ai_corrections:
                 console.print(f"[dim]AI corrected {len(ai_corrections)} audiobook(s)[/dim]\n")
+            else:
+                # Visibly confirm the AI path executed, even when no changes were needed.
+                console.print("[dim]AI verified — no corrections needed[/dim]\n")
         except Exception as e:
-            console.print(f"[yellow]AI verification failed: {e}[/yellow]\n")
+            # Don't silently swallow — make failures unmistakable in `kubectl logs`.
+            # We keep the try/except so a gateway hiccup doesn't abort the CronJob;
+            # processing continues with the un-verified inferred metadata.
+            console.print(
+                f"[bold red]AI verification ERRORED[/bold red] "
+                f"({type(e).__name__}): {e} — continuing with un-verified metadata\n"
+            )
+            logger.exception("AI batch verification failed")
 
     if dry_run:
         _show_dry_run(processor, sources, output)

--- a/tests/test_ai_batch.py
+++ b/tests/test_ai_batch.py
@@ -54,9 +54,7 @@ class TestAudiobookVerificationModel:
     """The model has narrator/year fields, defaulting to None."""
 
     def test_has_narrator_and_year_fields(self):
-        v = AudiobookVerification(
-            index=0, title="t", author="a", narrator="Rob Inglis", year=1968
-        )
+        v = AudiobookVerification(index=0, title="t", author="a", narrator="Rob Inglis", year=1968)
         assert v.narrator == "Rob Inglis"
         assert v.year == 1968
 

--- a/tests/test_ai_batch.py
+++ b/tests/test_ai_batch.py
@@ -1,0 +1,310 @@
+"""Tests for the AI batch verification path (ai_batch.py).
+
+Fully offline — `Agent.run_sync` and `_verify_batch_cached` are mocked via
+`monkeypatch`, no Anthropic / gateway / network calls. Real audio files are
+not needed: `read_embedded_tags` is stubbed where exercised.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from audiobook_optimizer.adapters import ai_batch
+from audiobook_optimizer.adapters.ai_batch import (
+    AudiobookVerification,
+    BatchAIVerifier,
+    BatchVerificationResult,
+    _format_items,
+    _verify_batch_cached,
+    apply_verification,
+)
+from audiobook_optimizer.domain.models import (
+    AudiobookMetadata,
+    AudiobookSource,
+    AudioFile,
+    AudioFormat,
+)
+
+
+def _make_source(folder: str, filenames: list[str], duration_ms: int = 3_600_000) -> AudiobookSource:
+    """Build an in-memory AudiobookSource pointing at fake paths (no I/O)."""
+    base = Path("/staging") / folder
+    audio_files = [
+        AudioFile(
+            path=base / name,
+            format=AudioFormat.MP3,
+            duration_ms=duration_ms // max(len(filenames), 1),
+            bitrate=64,
+            sample_rate=44100,
+            channels=1,
+        )
+        for name in filenames
+    ]
+    return AudiobookSource(
+        source_path=base,
+        audio_files=audio_files,
+        total_duration_ms=duration_ms,
+    )
+
+
+class TestAudiobookVerificationModel:
+    """The model has narrator/year fields, defaulting to None."""
+
+    def test_has_narrator_and_year_fields(self):
+        v = AudiobookVerification(
+            index=0, title="t", author="a", narrator="Rob Inglis", year=1968
+        )
+        assert v.narrator == "Rob Inglis"
+        assert v.year == 1968
+
+    def test_narrator_year_default_none(self):
+        v = AudiobookVerification(index=0, title="t", author="a")
+        assert v.narrator is None
+        assert v.year is None
+
+
+class TestApplyVerification:
+    """apply_verification: AI value wins when present, else fall back to existing metadata."""
+
+    def _base(self, **kw) -> AudiobookMetadata:
+        defaults = dict(title="Old Title", author="Old Author", series=None, series_number=None)
+        defaults.update(kw)
+        return AudiobookMetadata(**defaults)
+
+    def test_applies_ai_narrator_and_year(self):
+        meta = self._base()  # no narrator/year on the input
+        v = AudiobookVerification(
+            index=0,
+            title="New Title",
+            author="New Author",
+            narrator="Douglas Adams",
+            year=1979,
+        )
+        result = apply_verification(meta, v)
+        assert result.title == "New Title"
+        assert result.author == "New Author"
+        assert result.narrator == "Douglas Adams"
+        assert result.year == 1979
+
+    def test_falls_back_when_ai_null(self):
+        meta = self._base(narrator="Existing Narrator", year=2001)
+        v = AudiobookVerification(
+            index=0,
+            title="New Title",
+            author="New Author",
+            narrator=None,
+            year=None,
+        )
+        result = apply_verification(meta, v)
+        # AI returned null → keep the existing values, don't overwrite with None
+        assert result.narrator == "Existing Narrator"
+        assert result.year == 2001
+
+    def test_preserves_description_genre_cover(self):
+        meta = self._base(description="A book.", genre="SciFi", cover_path=Path("/tmp/c.jpg"))
+        v = AudiobookVerification(index=0, title="T", author="A")
+        result = apply_verification(meta, v)
+        assert result.description == "A book."
+        assert result.genre == "SciFi"
+        assert result.cover_path == Path("/tmp/c.jpg")
+
+
+class TestEnrichedItems:
+    """verify_batch enriches each item with parent_folder, total_hours, embedded_tags."""
+
+    def test_items_carry_enrichment(self, monkeypatch):
+        # Stub everything that would touch the network or filesystem
+        monkeypatch.setattr(ai_batch, "ai_available", lambda: True)
+        # The verifier reads settings.ai_model — stub get_settings to a known value
+        monkeypatch.setattr(
+            ai_batch,
+            "get_settings",
+            lambda: SimpleNamespace(ai_model="anthropic:claude-haiku-4-5"),
+        )
+
+        # Stub the embedded-tag reader on the local extractor
+        fake_tags = {
+            "artist": "Douglas Adams",
+            "albumartist": None,
+            "album": "The Hitchhiker's Guide to the Galaxy",
+            "composer": "Stephen Fry",  # the "wrong narrator" smell test
+            "date": "2005",
+            "comment": "Some descriptive blurb.",
+            "genre": "Audiobook",
+            "title": "01Hitchhiker's Guide to the Galaxy",
+        }
+        from audiobook_optimizer.adapters import filesystem as fs_mod
+
+        monkeypatch.setattr(
+            fs_mod.FilesystemMetadataExtractor,
+            "read_embedded_tags",
+            lambda self, source: fake_tags,
+        )
+
+        # Capture what gets passed into the cached verify call
+        captured = {}
+
+        def fake_cached(items, model):
+            captured["items"] = items
+            captured["model"] = model
+            return []  # no AI corrections needed for this assertion
+
+        monkeypatch.setattr(ai_batch, "_verify_batch_cached", fake_cached)
+
+        source = _make_source(
+            "01Hitchhiker's Guide to the Galaxy",
+            ["01Hitchhiker's Guide to the Galaxy (audiobook).mp3"],
+            duration_ms=3_600_000,  # exactly 1 hour
+        )
+        metadata = AudiobookMetadata(title="01Hitchhiker's Guide to the Galaxy", author="Unknown")
+        quality = {"bitrate": 64, "effective_bitrate": 64, "action": "transcode"}
+
+        verifier = BatchAIVerifier()
+        verifier.verify_batch([(source, metadata, quality)])
+
+        assert "items" in captured, "verify_batch did not call the cached function"
+        item = captured["items"][0]
+        assert item["folder"] == "01Hitchhiker's Guide to the Galaxy"
+        assert item["parent_folder"] == "staging"
+        assert item["total_hours"] == 1.0
+        assert item["embedded_tags"]["composer"] == "Stephen Fry"
+        assert item["embedded_tags"]["date"] == "2005"
+        assert item["embedded_tags"]["title"] == "01Hitchhiker's Guide to the Galaxy"
+        # Inferred is preserved
+        assert item["inferred"]["title"] == "01Hitchhiker's Guide to the Galaxy"
+        # Model threaded through
+        assert captured["model"] == "anthropic:claude-haiku-4-5"
+
+
+class TestFormatItems:
+    """_format_items renders enriched fields when present."""
+
+    def test_renders_embedded_tags_and_total_hours(self):
+        items = [
+            {
+                "index": 0,
+                "folder": "Some Book",
+                "parent_folder": "staging",
+                "files": ["chapter1.mp3"],
+                "file_count": 1,
+                "total_hours": 5.5,
+                "embedded_tags": {
+                    "artist": "Author Name",
+                    "composer": "Narrator Name",
+                    "date": None,
+                    "album": None,
+                },
+                "inferred": {
+                    "title": "Some Book",
+                    "author": "Author Name",
+                    "series": None,
+                    "series_number": None,
+                },
+                "quality": {"bitrate": 64, "effective_bitrate": 64, "action": "remux"},
+            }
+        ]
+        rendered = _format_items(items)
+        assert "(parent dir: staging)" in rendered
+        assert "~5.5h total" in rendered
+        assert "composer=Narrator Name" in rendered
+        # Null tag values are suppressed
+        assert "date=" not in rendered
+        assert "album=" not in rendered
+
+
+class TestRunSyncMocked:
+    """End-to-end: a stubbed PydanticAI Agent returns narrator/year and they flow back."""
+
+    def test_returns_expanded_verification(self, monkeypatch):
+        # Build a fake BatchVerificationResult with narrator+year populated
+        fake_verifications = [
+            AudiobookVerification(
+                index=0,
+                title="The Hitchhiker's Guide to the Galaxy",
+                author="Douglas Adams",
+                series="The Hitchhiker's Guide to the Galaxy",
+                series_number=1.0,
+                narrator="Douglas Adams",
+                year=1979,
+                changes=["normalized title", "added narrator from composer tag", "added year"],
+            )
+        ]
+        fake_result_output = BatchVerificationResult(
+            audiobooks=fake_verifications,
+            summary="1 audiobook corrected",
+        )
+        fake_agent_result = SimpleNamespace(output=fake_result_output)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_sync(self, prompt):
+                return fake_agent_result
+
+        # Patch the Agent class inside ai_batch's namespace (where it's imported as `Agent`)
+        monkeypatch.setattr(ai_batch, "Agent", FakeAgent)
+
+        # Try the __wrapped__ escape hatch (functools.wraps preserves the inner fn);
+        # if cachekit doesn't expose it, call _verify_batch_cached directly — Redis
+        # is not configured under pytest so it falls through to in-memory L1.
+        inner = getattr(_verify_batch_cached, "__wrapped__", _verify_batch_cached)
+
+        items = [
+            {
+                "folder": "01Hitchhiker's Guide to the Galaxy",
+                "parent_folder": "staging",
+                "files": ["01Hitchhiker's Guide to the Galaxy (audiobook).mp3"],
+                "file_count": 1,
+                "total_hours": 5.0,
+                "embedded_tags": {"composer": "Stephen Fry", "date": "2005"},
+                "inferred": {
+                    "title": "01Hitchhiker's Guide to the Galaxy",
+                    "author": "Unknown",
+                    "series": None,
+                    "series_number": None,
+                },
+                "quality": {"bitrate": 64, "effective_bitrate": 64, "action": "transcode"},
+            }
+        ]
+        out = inner(items, "anthropic:claude-haiku-4-5")
+        assert len(out) == 1
+        assert out[0]["narrator"] == "Douglas Adams"
+        assert out[0]["year"] == 1979
+        assert out[0]["title"] == "The Hitchhiker's Guide to the Galaxy"
+        assert out[0]["series"] == "The Hitchhiker's Guide to the Galaxy"
+
+
+class TestReadEmbeddedTagsContract:
+    """The new FilesystemMetadataExtractor.read_embedded_tags returns the expected keys
+    and degrades to all-None when mutagen can't read the file (no audio at the path)."""
+
+    def test_returns_all_none_when_file_missing(self, tmp_path):
+        from audiobook_optimizer.adapters.filesystem import FilesystemMetadataExtractor
+
+        source = _make_source("nonexistent", ["nope.mp3"])
+        extractor = FilesystemMetadataExtractor()
+        tags = extractor.read_embedded_tags(source)
+        # Contract: same keys every time, even on failure
+        expected_keys = {"artist", "albumartist", "album", "composer", "date", "comment", "genre", "title"}
+        assert set(tags.keys()) == expected_keys
+        assert all(v is None for v in tags.values())
+
+    def test_returns_all_none_when_no_audio_files(self):
+        from audiobook_optimizer.adapters.filesystem import FilesystemMetadataExtractor
+
+        empty_source = AudiobookSource(
+            source_path=Path("/nothing"),
+            audio_files=[],
+            total_duration_ms=0,
+        )
+        extractor = FilesystemMetadataExtractor()
+        tags = extractor.read_embedded_tags(empty_source)
+        assert all(v is None for v in tags.values())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes the optimizer's silent / impoverished AI metadata path so processed audiobooks land with clean title/series/narrator/year instead of garbage like `01Hitchhiker's Guide to the Galaxy`.

## Root cause

The `BatchAIVerifier` path already exists and runs (it's wired into the `process` CLI command), but underperforms because:

1. **Impoverished input** — the AI prompt is built from only the folder name, 5 filenames, and the filesystem-inferred title/author. It never sees embedded source tags (`artist`, `album`, `composer`, `date`, `comment`), total duration, or parent directory — the richest available signal.
2. **No narrator/year channel** — `AudiobookVerification` has no `narrator` or `year` field, so the AI cannot return them.
3. **Silent failure** — `cli.py` swallows any AI exception with a single yellow line; a gateway hiccup degrades to un-verified metadata invisibly.

## Changes

- `adapters/filesystem.py` — new `FilesystemMetadataExtractor.read_embedded_tags(source) -> dict` reusing the existing lazy-mutagen handle + `_get_tag` helper.
- `adapters/ai_batch.py`:
  - `AudiobookVerification` gains optional `narrator` + `year` fields.
  - `verify_batch` now passes `parent_folder`, `total_hours`, and `embedded_tags` (truncated to 300 chars/value) into each item dict. Cachekit auto-invalidates stale entries on input-shape change.
  - `_format_items` renders the new fields.
  - `_INSTRUCTIONS` rewritten with a `USING EMBEDDED TAGS` section: composer is frequently the narrator, date is frequently the year, embedded tags can be wrong on re-recordings/mislabels.
  - `apply_verification` applies AI narrator/year when present, falls back to existing metadata when null.
- `cli.py` — module logger added; explicit "AI verification skipped" when disabled; "AI verified — no corrections needed" when AI ran cleanly; `except` now prints a red `AI verification ERRORED (<ExcType>): <msg>` plus `logger.exception(...)`. try/except kept so a gateway hiccup doesn't abort the batch.
- `tests/test_ai_batch.py` (new) — 10 offline tests covering model fields, `apply_verification` fallback behaviour, items-dict enrichment, format rendering, end-to-end with a stubbed PydanticAI `Agent`, and `read_embedded_tags` contract.

## Tests

```
$ uv run pytest -q
98 passed in 0.32s
$ uv run ruff check src/ tests/
All checks passed!
```

## Rollout

After merge → `main` push triggers GHCR build → bump image tag in `27b-io/lab/k8s/media/audiobook-optimizer.yaml` → Flux reconciles.

End-to-end verification: re-stage one previously-bad book, manually trigger `kubectl create job --from=cronjob/audiobook-optimizer`, confirm `AI corrected N` in pod logs and clean tags on the output m4b.

Plan: `/home/fish/.claude/plans/dapper-swinging-hamster.md`