### PR TITLE
fix(ai): allow BatchVerificationResult.audiobooks to default to empty list

### DIFF
--- a/src/audiobook_optimizer/adapters/ai_batch.py
+++ b/src/audiobook_optimizer/adapters/ai_batch.py
@@ -43,7 +43,11 @@ class AudiobookVerification(BaseModel):
 class BatchVerificationResult(BaseModel):
     """Result of batch verification."""
 
-    audiobooks: list[AudiobookVerification] = Field(description="Verified audiobooks")
+    # default_factory=list lets the LLM omit `audiobooks` when it judges that
+    # no corrections are needed — without this, pydantic raises "Field required"
+    # on perfectly valid "summary-only" responses and the entire AI verification
+    # falls through to filename-based metadata. See lab task #19.
+    audiobooks: list[AudiobookVerification] = Field(default_factory=list, description="Verified audiobooks")
     summary: str = Field(description="Brief summary of verification")
 
 

--- a/tests/test_ai_batch.py
+++ b/tests/test_ai_batch.py
@@ -64,6 +64,28 @@ class TestAudiobookVerificationModel:
         assert v.year is None
 
 
+class TestBatchVerificationResultDefaults:
+    """audiobooks defaults to an empty list so the LLM can return summary-only.
+
+    Pydantic raised "Field required" when the LLM judged that no corrections
+    were needed and returned just `{"summary": "..."}` — the AI verification
+    would then fall through to filename-based metadata. The fix is to give
+    `audiobooks` a default empty list so an omitted/empty value is valid.
+    """
+
+    def test_audiobooks_defaults_to_empty_list(self):
+        # Schema must accept a summary-only response — this is what the LLM
+        # actually returned in the wild when nothing needed correcting.
+        r = BatchVerificationResult(summary="1 audiobook verified, no corrections needed")
+        assert r.audiobooks == []
+        assert r.summary == "1 audiobook verified, no corrections needed"
+
+    def test_audiobooks_can_still_be_populated(self):
+        v = AudiobookVerification(index=0, title="t", author="a")
+        r = BatchVerificationResult(audiobooks=[v], summary="1 verified")
+        assert r.audiobooks == [v]
+
+
 class TestApplyVerification:
     """apply_verification: AI value wins when present, else fall back to existing metadata."""
 


### PR DESCRIPTION
## Problem

When the LLM judges that an audiobook needs no corrections, it returns:

```json
{"summary": "1 audiobook verified, no corrections needed"}
```

Pydantic was rejecting this with `Field required` because `BatchVerificationResult.audiobooks` had no default. After two retries pydantic-ai gives up with `UnexpectedModelBehavior: Exceeded maximum retries (1) for output validation`, and `cli.py` falls back to filename-based metadata.

Hit this ~4 times during the Le Guin 95-book batch — each one a book where the deterministic pass had already produced clean output, so the LLM was correctly saying "nothing to fix" but couldn't express that in a schema-valid response.

## Fix

```python
audiobooks: list[AudiobookVerification] = Field(default_factory=list, description="Verified audiobooks")
```

One-line. The model's prompt already says "return X only when confident, else null" — this aligns the schema with that contract.

## Tests

Two new offline tests under `TestBatchVerificationResultDefaults`:
- `test_audiobooks_defaults_to_empty_list` — summary-only construction succeeds.
- `test_audiobooks_can_still_be_populated` — backward-compatible.

All 128 tests pass. Ruff clean.

## Verification path

After merge → image rebuild → bump tag in lab `k8s/media/audiobook-optimizer.yaml` → re-stage the books that were processed with AI-error fallback during the Le Guin batch.
